### PR TITLE
PacketInterface: save one round of packet processing (processed info …

### DIFF
--- a/Linux/Car_Client/packetinterface.cpp
+++ b/Linux/Car_Client/packetinterface.cpp
@@ -170,7 +170,7 @@ void PacketInterface::processData(QByteArray &data)
                 if (crc16(mRxBuffer, mPayloadLength) ==
                         ((unsigned short)mCrcHigh << 8 | (unsigned short)mCrcLow)) {
                     // Packet received!
-                    processPacket(mRxBuffer, mPayloadLength);
+                    emit packetReceived((quint8)data[0], (CMD_PACKET)(quint8)data[1], QByteArray((const char*)mRxBuffer, mPayloadLength));
                 }
             }
 
@@ -186,8 +186,6 @@ void PacketInterface::processData(QByteArray &data)
 
 void PacketInterface::processPacket(const unsigned char *data, int len)
 {
-    QByteArray pkt = QByteArray((const char*)data, len);
-
     unsigned char id = data[0];
     data++;
     len--;
@@ -195,8 +193,6 @@ void PacketInterface::processPacket(const unsigned char *data, int len)
     CMD_PACKET cmd = (CMD_PACKET)(quint8)data[0];
     data++;
     len--;
-
-    emit packetReceived(id, cmd, pkt);
 
     switch (cmd) {
     case CMD_PRINTF: {

--- a/Linux/RControlStation/packetinterface.cpp
+++ b/Linux/RControlStation/packetinterface.cpp
@@ -170,7 +170,7 @@ void PacketInterface::processData(QByteArray &data)
                 if (crc16(mRxBuffer, mPayloadLength) ==
                         ((unsigned short)mCrcHigh << 8 | (unsigned short)mCrcLow)) {
                     // Packet received!
-                    processPacket(mRxBuffer, mPayloadLength);
+                    emit packetReceived((quint8)data[0], (CMD_PACKET)(quint8)data[1], QByteArray((const char*)mRxBuffer, mPayloadLength));
                 }
             }
 
@@ -186,8 +186,6 @@ void PacketInterface::processData(QByteArray &data)
 
 void PacketInterface::processPacket(const unsigned char *data, int len)
 {
-    QByteArray pkt = QByteArray((const char*)data, len);
-
     unsigned char id = data[0];
     data++;
     len--;
@@ -195,8 +193,6 @@ void PacketInterface::processPacket(const unsigned char *data, int len)
     CMD_PACKET cmd = (CMD_PACKET)(quint8)data[0];
     data++;
     len--;
-
-    emit packetReceived(id, cmd, pkt);
 
     switch (cmd) {
     case CMD_PRINTF: {


### PR DESCRIPTION
…was not used)

I am not yet convinced this works in every case, but it reflects my current understanding of packet processing. Creating a pull request so that this thing is not forgotten...